### PR TITLE
feat: Add Dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Should automatically update the Node.js packages. For example, the latest version of ajv compatible with package.json is 6.12.6, [released 11 Oct 2020](https://github.com/ajv-validator/ajv/releases/tag/v6.12.6), while the latest version is https://github.com/ajv-validator/ajv/releases/tag/v8.8.1.