### PR TITLE
feat: Add Nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import
+    (
+      fetchTarball
+        {
+          name = "21.05";
+          url = "https://github.com/NixOS/nixpkgs/archive/7e9b0dff974c89e070da1ad85713ff3c20b0ca97.tar.gz";
+          sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
+        })
+    { }
+}:
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.nodejs
+  ];
+}


### PR DESCRIPTION
Enables an easily reproducible developer shell with the necessary
dependencies, without having to run a service like Docker or having to
configure anything.