### PR TITLE
feat: Run all actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         runner: [
           'macos-10.15',


### PR DESCRIPTION
The default is to cancel other jobs when one of the matrix jobs fail,
but we want to make sure the whole matrix is tested.