### PR TITLE
tests: Verify invalid schema handling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -44,9 +44,9 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   "coverageThreshold": {
     "global": {
-      "branches": 48,
-      "functions": 54,
-      "lines": 55
+      "branches": 65,
+      "functions": 81,
+      "lines": 69
     }
   }
 

--- a/tests/catalog-with-invalid-schema.json
+++ b/tests/catalog-with-invalid-schema.json
@@ -1,0 +1,9 @@
+{
+  "stac_version": "1.0.0",
+  "id": "example",
+  "type": "Catalog",
+  "title": "Example Catalog",
+  "description": "A minimal example for tests",
+  "stac_extensions": ["https://example.org/invalid-schema.json"],
+  "links": []
+}

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -4,6 +4,9 @@ const { version } = require('../package.json');
 let consoleErrSpy, consoleWarnSpy, consoleInfSpy, consoleLogSpy, mockExit;
 const initString = `STAC Node Validator v${version}`;
 
+const invalidSchemaPath = 'tests/invalid-schema.json';
+const invalidSchemaCatalogPath = 'tests/catalog-with-invalid-schema.json';
+
 beforeEach(() => {
 	mockExit = jest.spyOn(process, 'exit').mockImplementation();
 	consoleInfSpy = jest.spyOn(console, 'info').mockImplementation();
@@ -130,6 +133,28 @@ describe('Running with a simple catalog argument passed in via CLI', () => {
 		await app();
 
 		expect(consoleErrSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe('Running with an invalid schema', () => {
+	it('Should return exit code 1', async () => {
+		await app(
+			{'schemaMap': `https://example.org/invalid-schema.json=${invalidSchemaPath}`, 'files': [invalidSchemaCatalogPath]}
+		);
+
+		expect(mockExit).toHaveBeenCalledWith(1);
+	});
+
+	it('Should print informational messages', async () => {
+		await app(
+			{'schemaMap': `https://example.org/invalid-schema.json=${invalidSchemaPath}`, 'files': [invalidSchemaCatalogPath]}
+		);
+
+		expect(consoleLogSpy.mock.calls[0][0]).toContain(initString);
+		expect(consoleLogSpy.mock.calls[1][0]).toContain(invalidSchemaCatalogPath);
+		expect(consoleInfSpy.mock.calls[0][0]).toContain('Files: 1');
+		expect(consoleInfSpy.mock.calls[1][0]).toContain('Valid: 0');
+		expect(consoleInfSpy.mock.calls[2][0]).toContain('Invalid: 1');
 	});
 });
 

--- a/tests/invalid-schema.json
+++ b/tests/invalid-schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.org/invalid-schema.json",
+  "title": "Invalid schema",
+  "anyOf": {}
+}


### PR DESCRIPTION
This does *not* test the error message printed, for two reasons:

1. The original message comes from Ajv, which is outside the scope of
   this test.
2. The message sent to `console.error` when inspecting the spy in the
   test, '--- https://example.org/invalid-schema.json: anyOf value must
   be ["array"]', is slightly different from the one actually printed to
   standard error when running the command, '---
   https://example.org/invalid-schema.json: schema is invalid:
   data/anyOf must be array'.

Closes #20.