### PR TITLE
Allow host to be empty string for local file:/// paths

### DIFF
--- a/iri.js
+++ b/iri.js
@@ -20,7 +20,7 @@ module.exports = {
 		}
 
 		const iri = parse(value);
-		if ((iri.reference === 'absolute' || iri.reference === 'uri') && iri.scheme && typeof iri.host !== 'undefined') {
+		if ((iri.reference === 'absolute' || iri.reference === 'uri') && iri.scheme && (iri.host || (iri.scheme === 'file' && iri.path))) {
 			return true;
 		}
 

--- a/iri.js
+++ b/iri.js
@@ -20,7 +20,7 @@ module.exports = {
 		}
 
 		const iri = parse(value);
-		if ((iri.reference === 'absolute' || iri.reference === 'uri') && iri.scheme && (iri.host !== undefined)) {
+		if ((iri.reference === 'absolute' || iri.reference === 'uri') && iri.scheme && typeof iri.host !== 'undefined') {
 			return true;
 		}
 

--- a/iri.js
+++ b/iri.js
@@ -20,7 +20,7 @@ module.exports = {
 		}
 
 		const iri = parse(value);
-		if ((iri.reference === 'absolute' || iri.reference === 'uri') && iri.scheme && iri.host) {
+		if ((iri.reference === 'absolute' || iri.reference === 'uri') && iri.scheme && (iri.host !== undefined)) {
 			return true;
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stac-node-validator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "STAC Validator for NodeJS",
   "author": "Matthias Mohr",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stac-node-validator",
-  "version": "1.3.2",
+  "version": "1.3.1",
   "description": "STAC Validator for NodeJS",
   "author": "Matthias Mohr",
   "license": "Apache-2.0",


### PR DESCRIPTION
I needed to make this change for the validator to allow hrefs like the following:

```
file:///path/to/the%20file.txt
```

For a local file, the hostname is omitted, but the slash is not (note the third slash). So the hostname is the empty string, not undefined.

------
Test Suites: 1 passed, 1 total
Tests:       31 passed, 31 total
